### PR TITLE
Add/change ownership logic to mintable

### DIFF
--- a/test/ERC20ForSPL.js
+++ b/test/ERC20ForSPL.js
@@ -47,7 +47,7 @@ let neon_getEvmParams;
 const TOKEN_MINT = config.utils.publicKeyToBytes32(config.DATA.ADDRESSES.ERC20ForSplTokenMint);
 const TOKEN_MINT_DECIMALS = 9;
 const RECEIPTS_COUNT = 1;
-const SOLANA_TX_TIMEOUT = 20000;
+const SOLANA_TX_TIMEOUT = 10000;
 
 describe('Test init', async function () {
     before(async function() {

--- a/test/ERC20ForSPLMintable.js
+++ b/test/ERC20ForSPLMintable.js
@@ -560,6 +560,15 @@ describe('Test init',  function () {
                 expect(await ERC20ForSPLMintable.owner()).to.equal(initialOwner);
             });
 
+            it('Test zero address ownership change', async function () {
+                await expect(
+                    ERC20ForSPLMintable.connect(owner).transferOwnership(ethers.ZeroAddress)
+                ).to.be.revertedWithCustomError(
+                    ERC20ForSPLMintable,
+                    'OwnableInvalidOwner'
+                );
+            });
+
             it('Test malicious ownership change', async function () {
                 await expect(
                     ERC20ForSPLMintable.connect(user1).transferOwnership(user1.address)

--- a/test/ERC20ForSPLMintable.js
+++ b/test/ERC20ForSPLMintable.js
@@ -560,6 +560,24 @@ describe('Test init',  function () {
                 expect(await ERC20ForSPLMintable.owner()).to.equal(initialOwner);
             });
 
+            it('Test malicious ownership change', async function () {
+                await expect(
+                    ERC20ForSPLMintable.connect(user1).transferOwnership(user1.address)
+                ).to.be.revertedWithCustomError(
+                    ERC20ForSPLMintable,
+                    'OwnableUnauthorizedAccount'
+                );
+            });
+
+            it('Test malicious ownership renounce', async function () {
+                await expect(
+                    ERC20ForSPLMintable.connect(user1).renounceOwnership()
+                ).to.be.revertedWithCustomError(
+                    ERC20ForSPLMintable,
+                    'OwnableUnauthorizedAccount'
+                );
+            });
+
             it('Test reverting of contract deployed with decimals greater than 9', async function () {
                 // Call burn with amount > type(uint64).max
                 await expect(

--- a/test/ERC20ForSPLMintable.js
+++ b/test/ERC20ForSPLMintable.js
@@ -28,7 +28,7 @@ describe('Test init',  function () {
     const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
     const ZERO_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
     const RECEIPTS_COUNT = 3;
-    const TIMEOUT = 3000;
+    const TIMEOUT = 10000;
     const other  = ethers.Wallet.createRandom()
     const other2 = ethers.Wallet.createRandom();
     let owner, user1, user2, user3;
@@ -241,12 +241,17 @@ describe('Test init',  function () {
     });
 
     describe('ERC20ForSPLMintable tests',  function() {
-
         it('Empty storage slots', async function () {
             for (let i = 0; i < 100; ++i) {
-                expect(await ethers.provider.getStorage(ERC20ForSPLMintable.target, i)).to.eq(
-                    '0x0000000000000000000000000000000000000000000000000000000000000000'
-                );
+                if (i == 1) {
+                    expect(await ethers.provider.getStorage(ERC20ForSPLMintable.target, i)).to.eq(
+                        ethers.zeroPadValue(owner.address, 32)
+                    );
+                } else {
+                    expect(await ethers.provider.getStorage(ERC20ForSPLMintable.target, i)).to.eq(
+                        '0x0000000000000000000000000000000000000000000000000000000000000000'
+                    );
+                }
             }
         });
 
@@ -536,6 +541,23 @@ describe('Test init',  function () {
                 // Check approver's delegatedAmount and delegate after claim
                 expect((await getAccount(connection, solanaApproverATA)).delegatedAmount).to.equal(ZERO_AMOUNT);
                 expect((await getAccount(connection, solanaApproverATA)).delegate).to.be.null;
+            });
+
+            it('Test ownership change', async function () {
+                let initialOwner = await ERC20ForSPLMintable.owner();
+                console.log(initialOwner, 'initialOwner');
+
+                let tx = await ERC20ForSPLMintable.transferOwnership(user1.address);
+                await tx.wait(RECEIPTS_COUNT);
+
+                expect(await ERC20ForSPLMintable.owner()).to.equal(user1.address);
+                expect(await ERC20ForSPLMintable.owner()).to.not.equal(initialOwner);
+
+                // switch back to the initial owner
+                tx = await ERC20ForSPLMintable.connect(user1).transferOwnership(owner.address);
+                await tx.wait(RECEIPTS_COUNT);
+
+                expect(await ERC20ForSPLMintable.owner()).to.equal(initialOwner);
             });
 
             it('Test reverting of contract deployed with decimals greater than 9', async function () {
@@ -1583,11 +1605,11 @@ describe('Test init',  function () {
             })
         })
 
-        it('mint: malicious mint reverts with InvalidOwner custom error', async function () {
+        it('mint: malicious mint reverts with OwnableUnauthorizedAccount OZ error', async function () {
             // Call mint from user1 (not owner)
             await expect(ERC20ForSPLMintable.connect(user1).mint(user1.address, AMOUNT)).to.be.revertedWithCustomError(
                 ERC20ForSPLMintable,
-                'InvalidOwner'
+                'OwnableUnauthorizedAccount'
             );
         });
 

--- a/test/config.js
+++ b/test/config.js
@@ -199,7 +199,7 @@ const config = {
                     )
                 });
             },
-            buildTransactionBody: function(payer, nonce, chainId, target, callData) {
+            buildTransactionBody: async function(signerAddress, payer, nonce, chainId, target, callData) {
                 if (parseInt(nonce, 16) == 0) {
                     nonce = '0x'
                 } else {
@@ -221,8 +221,8 @@ const config = {
                         value: '0x',
                         chainId: ethers.toBeHex(parseInt(chainId, 16)),
                         gasLimit: ethers.toBeHex(9999999),
-                        maxFeePerGas: ethers.toBeHex(5000000000000),
-                        maxPriorityFeePerGas: ethers.toBeHex(Date.now())
+                        maxFeePerGas: ethers.toBeHex(50000000000),
+                        maxPriorityFeePerGas: ethers.toBeHex(10000000000)
                     }
                 }
             
@@ -258,7 +258,8 @@ const config = {
                 const chainId = (await eth_chainIdRequest.json()).result;
 
                 const neonEvmProgram = new web3.PublicKey(neon_getEvmParams.result.neonEvmProgramId);
-                const neonTransaction = this.buildTransactionBody(
+                const neonTransaction = await this.buildTransactionBody(
+                    signerAddress,
                     payer,
                     nonce,
                     chainId,
@@ -270,7 +271,6 @@ const config = {
                 const [treeAccountAddress] = this.neonTreeAccountAddressSync(payer, neonEvmProgram, nonce, parseInt(chainId, 16));
                 const [authorityPoolAddress] = this.neonAuthorityPoolAddressSync(neonEvmProgram);
                 const associatedTokenAddress = await getAssociatedTokenAddress(new web3.PublicKey('So11111111111111111111111111111111111111112'), authorityPoolAddress, true);
-
 
                 const index = Math.floor(Math.random() * neon_getEvmParams.result.neonTreasuryPoolCount) % neon_getEvmParams.result.neonTreasuryPoolCount;
                 const treasuryPool = {


### PR DESCRIPTION
Change log
- Add OZ's `Ownable` library to the mintable version in order to support ownership change
- Add test scenarios for the `Ownable` library
- Change `public` visiblity of methods to `external` - not for gas efficiency, but it's better practise to limit access as much as possible