### PR TITLE
Add/core devs feedback part two

### DIFF
--- a/contracts/token/ERC20ForSpl/erc20_for_spl.sol
+++ b/contracts/token/ERC20ForSpl/erc20_for_spl.sol
@@ -135,21 +135,16 @@ contract ERC20ForSplBackbone {
         return _balanceOfPDA(solanaAccount(account)) + _balanceOfATA(account);
     }
 
+    /// @notice Token balance getter function for the user's PDA account
+    /// @param account The NeonEVM address to get the balance of
     function balanceOfPDA(address account) external view returns (uint64) {
         return _balanceOfPDA(solanaAccount(account));
     }
 
+    /// @notice Token balance getter function for the user's ATA account ( a Solana user )
+    /// @param account The NeonEVM address to get the balance of
     function balanceOfATA(address account) external view returns (uint64) {
         return _balanceOfATA(account);
-    }
-
-    function _balanceOfPDA(bytes32 account) internal view returns (uint64) {
-        return SPLTOKEN_PROGRAM.getAccount(account).amount;
-    }
-
-    function _balanceOfATA(address account) internal view returns (uint64) {
-        (, uint64 ataBalance) = _getSolanaATA(account, false);
-        return ataBalance;
     }
 
     /// @notice Token ERC20 allowance getter function
@@ -451,6 +446,19 @@ contract ERC20ForSplBackbone {
     /// @return A 32 bytes salt used to derive the NeonEVM arbitrary token account attributed to the `account` address
     function _salt(address account) internal pure returns (bytes32) {
         return bytes32(uint256(uint160(account)));
+    }
+
+    /// @notice Internal token balance getter function for the user's PDA account
+    /// @param account The NeonEVM address to get the balance of
+    function _balanceOfPDA(bytes32 account) internal view returns (uint64) {
+        return SPLTOKEN_PROGRAM.getAccount(account).amount;
+    }
+
+    /// @notice Internal token balance getter function for the user's ATA account ( a Solana user )
+    /// @param account The NeonEVM address to get the balance of
+    function _balanceOfATA(address account) internal view returns (uint64) {
+        (, uint64 ataBalance) = _getSolanaATA(account, false);
+        return ataBalance;
     }
 }
 

--- a/contracts/token/ERC20ForSpl/erc20_for_spl_factory.sol
+++ b/contracts/token/ERC20ForSpl/erc20_for_spl_factory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {ERC20ForSpl, ERC20ForSplMintable} from './erc20_for_spl.sol';
+import {ERC20ForSplBackbone, ERC20ForSpl, ERC20ForSplMintable} from './erc20_for_spl.sol';
 
 
 /// @title ERC20ForSplFactory
@@ -64,5 +64,9 @@ contract ERC20ForSplFactory {
 
     function allErc20ForSplLength() external view returns (uint) {
         return allErc20ForSpl.length;
+    }
+
+    function getTokenMintByAddress(address token) external view returns (bytes32) {
+        return ERC20ForSplBackbone(token).tokenMint();
     }
 }

--- a/contracts/token/ERC20ForSpl/erc20_for_spl_factory.sol
+++ b/contracts/token/ERC20ForSpl/erc20_for_spl_factory.sol
@@ -1,30 +1,41 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.12;
+pragma solidity 0.8.28;
 
-import './erc20_for_spl.sol';
+import {ERC20ForSpl, ERC20ForSplMintable} from './erc20_for_spl.sol';
 
+
+/// @title ERC20ForSplFactory
+/// @author https://twitter.com/mnedelchev_
+/// @notice This contract serves as a factory to deploy ERC20ForSpl or ERC20ForSplMintable smart contracts.
+/// @notice ERC20ForSpl is used for the creation of Solidity smart contract interface of already existing SPLToken on Solana.
+/// @notice ERC20ForSplMintable mints new SPLToken on Solana and creates Solidity smart contract interface for it.
 contract ERC20ForSplFactory {
-
     mapping(bytes32 => address) public getErc20ForSpl;
     address[] public allErc20ForSpl;
 
+    /// @dev Event being emitted when a new Erc20ForSpl or Erc20ForSplMintable interface has been deployed
     event ERC20ForSplCreated(bytes32 _mint, address pair, uint);
 
-    function allErc20ForSplLength() external view returns (uint) {
-        return allErc20ForSpl.length;
-    }
+    /// @dev Custom error indicating that there is an existing Erc20ForSpl interface for the particular token mint
+    error ERC20ForSplAlreadyExists(bytes32 mint);
+    /// @dev Custom error indicating that the create2 deploying request of the Erc20ForSpl interface has failed
+    error ERC20ForSplNotCreated();
+    /// @dev Custom error indicating that the create2 deploying request of the Erc20ForSplMintable interface has failed
+    error ERC20ForSplMintableNotCreated();
 
-    function createErc20ForSpl(bytes32 _mint) public returns (address erc20spl) {
+    /// @notice Creation of Solidity smart contract interface of already existing SPLToken on Solana
+    /// @param _mint The Solana-like address of the Token Mint on Solana in bytes32 format
+    function createErc20ForSpl(bytes32 _mint) external returns (address erc20spl) {
+        require(getErc20ForSpl[_mint] == address(0), ERC20ForSplAlreadyExists(_mint));
 
-        require(getErc20ForSpl[_mint] == address(0), 'ERC20 SPL Factory: ERC20_SPL_EXISTS');
-
-        bytes memory bytecode = type(ERC20ForSpl).creationCode;
-        bytecode = abi.encodePacked(bytecode, abi.encode(_mint));
-        bytes32 salt = keccak256(abi.encodePacked(_mint));
+        bytes memory bytecode = abi.encodePacked(type(ERC20ForSpl).creationCode, abi.encode(_mint));
         assembly {
-            erc20spl := create2(0, add(bytecode, 32), mload(bytecode), salt)
+            let currentPointer := mload(0x40)
+            mstore(currentPointer, _mint)
+            erc20spl := create2(0, add(bytecode, 0x20), mload(bytecode), keccak256(currentPointer, 0x20))
+            mstore(0x40, add(currentPointer, 0x20))
         }
-        require(erc20spl != address(0), 'ERC20 SPL Factory: SPL TOKEN IS NOT CREATED');
+        require(erc20spl != address(0), ERC20ForSplNotCreated());
 
         getErc20ForSpl[_mint] = erc20spl;
         allErc20ForSpl.push(erc20spl);
@@ -32,20 +43,26 @@ contract ERC20ForSplFactory {
         emit ERC20ForSplCreated(_mint, erc20spl, allErc20ForSpl.length);
     }
 
-    function createErc20ForSplMintable(string memory _name, string memory _symbol, uint8 _decimals, address _mint_authority) public returns (address erc20spl) {
-
-        bytes memory bytecode = type(ERC20ForSplMintable).creationCode;
-        bytecode = abi.encodePacked(bytecode, abi.encode(_name, _symbol, _decimals, _mint_authority));
-        bytes32 salt = keccak256(abi.encodePacked(bytes32(0)));
+    /// @notice Minting a new SPLToken on Solana and creating a Solidity smart contract interface pointing to the SPLToken
+    /// @param _name The name of the SPLToken. This data is being stored inside the Metaplex program on Solana
+    /// @param _symbol The symbol of the SPLToken. This data is being stored inside the Metaplex program on Solana
+    /// @param _decimals The decimals of the SPLToken on Solana
+    /// @param _mint_authority The owner of the ERC20ForSPLMintable contract, which has the permissions to mint new tokens
+    function createErc20ForSplMintable(string memory _name, string memory _symbol, uint8 _decimals, address _mint_authority) external returns (address erc20spl) {
+        bytes memory bytecode = abi.encodePacked(type(ERC20ForSplMintable).creationCode, abi.encode(_name, _symbol, _decimals, _mint_authority));
         assembly {
-            erc20spl := create2(0, add(bytecode, 32), mload(bytecode), salt)
+            erc20spl := create2(0, add(bytecode, 0x20), mload(bytecode), keccak256(add(0, 0x20), 0x20))
         }
-        require(erc20spl != address(0), 'ERC20 SPL Factory: SPL TOKEN MINTABLE IS NOT CREATED');
+        require(erc20spl != address(0), ERC20ForSplMintableNotCreated());
 
         bytes32 _mint = ERC20ForSplMintable(erc20spl).findMintAccount();
         getErc20ForSpl[_mint] = erc20spl;
         allErc20ForSpl.push(erc20spl);
 
         emit ERC20ForSplCreated(_mint, erc20spl, allErc20ForSpl.length);
+    }
+
+    function allErc20ForSplLength() external view returns (uint) {
+        return allErc20ForSpl.length;
     }
 }

--- a/test/ERC20ForSPL.js
+++ b/test/ERC20ForSPL.js
@@ -47,7 +47,7 @@ let neon_getEvmParams;
 const TOKEN_MINT = config.utils.publicKeyToBytes32(config.DATA.ADDRESSES.ERC20ForSplTokenMint);
 const TOKEN_MINT_DECIMALS = 9;
 const RECEIPTS_COUNT = 1;
-const SOLANA_TX_TIMEOUT = 10000;
+const SOLANA_TX_TIMEOUT = 15000;
 
 describe('Test init', async function () {
     before(async function() {
@@ -890,6 +890,7 @@ describe('Test init', async function () {
                 it('validate balanceOf logic - only ATA balance should be increasing on token receive', async function () {
                     const payer = config.utils.SolanaNativeHelper.getPayer(solanaUser1);
                     const payerInitialBalanceOf = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfATA = await ERC20ForSPL.balanceOfATA(payer);
 
                     const solanaUser1ATA = await getAssociatedTokenAddress(
                         new web3.PublicKey(config.DATA.ADDRESSES.ERC20ForSplTokenMint),
@@ -914,8 +915,10 @@ describe('Test init', async function () {
 
                     // make sure only PDA account balance has increased
                     const payerBalanceOfAfter = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfATAAfter = await ERC20ForSPL.balanceOfATA(payer);
                     const amountInATAAccountAfter = (await getAccount(connection, solanaUser1ATA)).amount;
                     expect(payerBalanceOfAfter).to.be.greaterThan(payerInitialBalanceOf);
+                    expect(payerInitialBalanceOfATAAfter).to.be.greaterThan(payerInitialBalanceOfATA);
                     expect(amountInATAAccountAfter).to.be.greaterThan(amountInATAAccount);
                     expect(payerBalanceOfAfter).to.eq(amountInATAAccountAfter);
                 });
@@ -990,6 +993,7 @@ describe('Test init', async function () {
                         expect( await ERC20ForSPL.allowance(user2.address, payer)).to.be.greaterThan(0);
 
                         const currentBalancePayer = await ERC20ForSPL.balanceOf(payer);
+                        const currentBalancePayerATA = await ERC20ForSPL.balanceOfATA(payer);
                         const currentBalanceUser2 = await ERC20ForSPL.balanceOf(user2.address);
 
                         let balanceBeforeTx = await connection.getBalance(solanaUser1.publicKey);
@@ -1010,6 +1014,7 @@ describe('Test init', async function () {
                         expect(amountInATAAccountAfter).to.be.greaterThan(amountInATAAccount);
                         expect(amountInATAAccountAfter).to.eq(amountInATAAccount + transferAmount);
                         expect(await ERC20ForSPL.balanceOf(payer)).to.be.greaterThan(currentBalancePayer);
+                        expect(await ERC20ForSPL.balanceOfATA(payer)).to.be.greaterThan(currentBalancePayerATA);
                         expect(currentBalanceUser2).to.be.greaterThan(await ERC20ForSPL.balanceOf(user2.address));
                     } else {
                         this.skip();
@@ -1053,6 +1058,7 @@ describe('Test init', async function () {
                         expect(await ERC20ForSPL.allowance(payer, MockVault.target)).to.eq(transferAmount);
 
                         const currentBalancePayer = await ERC20ForSPL.balanceOf(payer);
+                        const currentBalancePayerATA = await ERC20ForSPL.balanceOfATA(payer);
                         const currentBalanceMockVault = await ERC20ForSPL.balanceOf(MockVault.target);
 
                         balanceBeforeTx = await connection.getBalance(solanaUser1.publicKey);
@@ -1073,6 +1079,7 @@ describe('Test init', async function () {
                         expect(amountInATAAccount).to.be.greaterThan(amountInATAAccountAfter);
                         expect(amountInATAAccount).to.eq(amountInATAAccountAfter + transferAmount);
                         expect(currentBalancePayer).to.be.greaterThan(await ERC20ForSPL.balanceOf(payer));
+                        expect(currentBalancePayerATA).to.be.greaterThan(await ERC20ForSPL.balanceOfATA(payer));
                         expect(currentBalancePayer).to.eq(await ERC20ForSPL.balanceOf(payer) + transferAmount);
                         expect(await ERC20ForSPL.balanceOf(MockVault.target)).to.be.greaterThan(currentBalanceMockVault);
                         expect(await ERC20ForSPL.balanceOf(MockVault.target)).to.eq(currentBalanceMockVault + transferAmount);
@@ -1281,6 +1288,7 @@ describe('Test init', async function () {
                 it('validate balanceOf logic - only PDA balance should be increasing on token receive', async function () {
                     const payer = config.utils.SolanaNativeHelper.getPayer(solanaUser3);
                     const payerInitialBalanceOf = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfPDA = await ERC20ForSPL.balanceOfPDA(payer);
 
                     const solanaUser3ATA = await getAssociatedTokenAddress(
                         new web3.PublicKey(config.DATA.ADDRESSES.ERC20ForSplTokenMint),
@@ -1306,8 +1314,10 @@ describe('Test init', async function () {
 
                     // make sure only PDA account balance has increased
                     const payerBalanceOfAfter = await ERC20ForSPL.balanceOf(payer);
+                    const payerBalanceOfPDAAfter = await ERC20ForSPL.balanceOf(payer);
                     const amountInPDAAccountAfter = (await getAccount(connection, solanaUser3PDA)).amount;
                     expect(payerBalanceOfAfter).to.be.greaterThan(payerInitialBalanceOf);
+                    expect(payerBalanceOfPDAAfter).to.be.greaterThan(payerInitialBalanceOfPDA);
                     expect(amountInPDAAccountAfter).to.be.greaterThan(amountInPDAAccount);
                     expect(payerBalanceOfAfter).to.eq(amountInPDAAccountAfter);
                 });
@@ -1315,6 +1325,7 @@ describe('Test init', async function () {
                 it('transfer part of the PDA balance to owner', async function () {
                     const payer = config.utils.SolanaNativeHelper.getPayer(solanaUser3);
                     const payerInitialBalanceOf = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfPDA = await ERC20ForSPL.balanceOfPDA(payer);
                     const ownerInitialBalanceOf = await ERC20ForSPL.balanceOf(owner.address);
                     
                     const solanaUser3PDA = config.utils.calculatePdaAccount(
@@ -1341,10 +1352,12 @@ describe('Test init', async function () {
                     console.log('Paid -', (balanceBeforeTx - await connection.getBalance(solanaUser3.publicKey)) / 10 ** TOKEN_MINT_DECIMALS, 'SOLs', '\n');
 
                     const payerBalanceOfAfter = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfPDAAfter = await ERC20ForSPL.balanceOfPDA(payer);
                     const ownerBalanceOfAfter = await ERC20ForSPL.balanceOf(owner.address);
                     const amountInPDAAccountAfter = (await getAccount(connection, solanaUser3PDA)).amount;
 
                     expect(payerInitialBalanceOf).to.be.greaterThan(payerBalanceOfAfter);
+                    expect(payerInitialBalanceOfPDA).to.be.greaterThan(payerInitialBalanceOfPDAAfter);
                     expect(ownerBalanceOfAfter).to.be.greaterThan(ownerInitialBalanceOf);
                     expect(amountInPDAAccount).to.be.greaterThan(amountInPDAAccountAfter);
                     expect(amountInPDAAccount).to.eq(amountInPDAAccountAfter + transferAmount);
@@ -1353,6 +1366,7 @@ describe('Test init', async function () {
                 it('transferFrom all of the PDA balance to MockVault smart contract', async function () {
                     const payer = config.utils.SolanaNativeHelper.getPayer(solanaUser3);
                     const payerInitialBalanceOf = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfPDA = await ERC20ForSPL.balanceOfPDA(payer);
                     const mockVaultInitialBalanceOf = await ERC20ForSPL.balanceOf(MockVault.target);
                     
                     const solanaUser3PDA = config.utils.calculatePdaAccount(
@@ -1394,10 +1408,12 @@ describe('Test init', async function () {
                     console.log('Paid -', (balanceBeforeTx - await connection.getBalance(solanaUser3.publicKey)) / 10 ** TOKEN_MINT_DECIMALS, 'SOLs', '\n');
 
                     const payerBalanceOfAfter = await ERC20ForSPL.balanceOf(payer);
+                    const payerInitialBalanceOfPDAAfter = await ERC20ForSPL.balanceOfPDA(payer);
                     const mockVaultBalanceOfAfter = await ERC20ForSPL.balanceOf(MockVault.target);
                     const amountInPDAAccountAfter = (await getAccount(connection, solanaUser3PDA)).amount;
 
                     expect(payerInitialBalanceOf).to.be.greaterThan(payerBalanceOfAfter);
+                    expect(payerInitialBalanceOfPDA).to.be.greaterThan(payerInitialBalanceOfPDAAfter);
                     expect(mockVaultBalanceOfAfter).to.be.greaterThan(mockVaultInitialBalanceOf);
                     expect(amountInPDAAccount).to.be.greaterThan(amountInPDAAccountAfter);
                     expect(amountInPDAAccount).to.eq(amountInPDAAccountAfter + transferAmount);

--- a/test/ERC20ForSplFactory.js
+++ b/test/ERC20ForSplFactory.js
@@ -1,0 +1,112 @@
+const { ethers } = require("hardhat");
+const { expect } = require("chai");
+const web3 = require("@solana/web3.js");
+const { config } = require('./config');
+require("dotenv").config();
+
+let owner;
+const ERC20ForSPLFactoryAddress = config.DATA.ADDRESSES.ERC20ForSplFactory;
+let ERC20ForSPLFactory;
+let ERC20ForSPL;
+let ERC20ForSPLMintable;
+let ERC20ForSplContractFactory;
+let ERC20ForSplMintableContractFactory;
+const TOKEN_MINT = config.utils.publicKeyToBytes32(config.DATA.ADDRESSES.ERC20ForSplTokenMint);
+const RECEIPTS_COUNT = 1;
+
+describe('Test init', async function () {
+    before(async function() {
+        [owner] = await ethers.getSigners();
+
+        if (await ethers.provider.getBalance(owner.address) == 0) {
+            await config.utils.airdropNEON(owner.address);
+        }
+
+        const ERC20ForSplFactoryContractFactory = await ethers.getContractFactory('contracts/token/ERC20ForSpl/erc20_for_spl_factory.sol:ERC20ForSplFactory');
+        ERC20ForSplContractFactory = await ethers.getContractFactory('contracts/token/ERC20ForSpl/erc20_for_spl.sol:ERC20ForSpl');
+        ERC20ForSplMintableContractFactory = await ethers.getContractFactory('contracts/token/ERC20ForSpl/erc20_for_spl.sol:ERC20ForSplMintable');
+        
+        if (ethers.isAddress(ERC20ForSPLFactoryAddress)) {
+            console.log('\nCreating instance of already deployed ERC20ForSPLFactory contract on Neon EVM with address', "\x1b[32m", ERC20ForSPLFactoryAddress, "\x1b[30m", '\n');
+            ERC20ForSPLFactory = ERC20ForSplFactoryContractFactory.attach(ERC20ForSPLFactoryAddress);
+        } else {
+            // deploy ERC20ForSPLFactory
+            ERC20ForSPLFactory = await ethers.deployContract('contracts/token/ERC20ForSpl/erc20_for_spl_factory.sol:ERC20ForSplFactory');
+            await ERC20ForSPLFactory.waitForDeployment();
+            console.log('\nCreating instance of just now deployed ERC20ForSplFactory contract on Neon EVM with address', "\x1b[32m", ERC20ForSPLFactory.target, "\x1b[30m", '\n'); 
+        }
+    });
+
+    describe('ERC20ForSPL tests', function() {
+        it('createErc20ForSpl', async function () {
+            if (TOKEN_MINT == '') {
+                this.skip();
+            }
+
+            tx = await ERC20ForSPLFactory.createErc20ForSpl(TOKEN_MINT);
+            await tx.wait(RECEIPTS_COUNT);
+
+            const getErc20ForSpl = await ERC20ForSPLFactory.getErc20ForSpl(TOKEN_MINT);
+            expect(getErc20ForSpl).to.not.eq(ethers.ZeroAddress);
+            expect(await ethers.provider.getCode(getErc20ForSpl)).to.not.eq('0x');
+
+            ERC20ForSPL = ERC20ForSplContractFactory.attach(getErc20ForSpl);
+        });
+
+        it('createErc20ForSplMintable', async function () {
+            tx = await ERC20ForSPLFactory.createErc20ForSplMintable(
+                "Test",
+                "TESTCOIN",
+                9,
+                owner.address
+            );
+            await tx.wait(RECEIPTS_COUNT);
+
+            const getErc20ForSplMintable = await ERC20ForSPLFactory.allErc20ForSpl(
+                parseInt((await ERC20ForSPLFactory.allErc20ForSplLength()).toString()) - 1
+            );
+            expect(getErc20ForSplMintable).to.not.eq(ethers.ZeroAddress);
+            expect(await ethers.provider.getCode(getErc20ForSplMintable)).to.not.eq('0x');
+
+            ERC20ForSPLMintable = ERC20ForSplMintableContractFactory.attach(getErc20ForSplMintable);
+        });
+
+        it('allErc20ForSplLength', async function () {
+            expect(await ERC20ForSPLFactory.allErc20ForSplLength()).to.eq(2);
+        });
+        
+        describe('Reverts',  function() {
+            it('ERC20ForSplAlreadyExists', async function () {
+                await expect(
+                    ERC20ForSPLFactory.createErc20ForSpl(TOKEN_MINT)
+                ).to.be.revertedWithCustomError(
+                    ERC20ForSPLFactory,
+                    'ERC20ForSplAlreadyExists'
+                );
+            });
+
+            it('ERC20ForSplNotCreated', async function () {
+                await expect(
+                    ERC20ForSPLFactory.createErc20ForSpl("0x0000000000000000000000000000000000000000000000000000000000000001")
+                ).to.be.revertedWithCustomError(
+                    ERC20ForSPLFactory,
+                    'ERC20ForSplNotCreated'
+                );
+            });
+            
+            it('ERC20ForSplMintableNotCreated', async function () {
+                await expect(
+                    ERC20ForSPLFactory.createErc20ForSplMintable(
+                        "Test",
+                        "TESTCOIN",
+                        9,
+                        ethers.ZeroAddress
+                    )
+                ).to.be.revertedWithCustomError(
+                    ERC20ForSPLFactory,
+                    'ERC20ForSplMintableNotCreated'
+                );
+            });
+        });
+    });
+});

--- a/test/config.js
+++ b/test/config.js
@@ -31,12 +31,9 @@ const config = {
             const seed = [
                 new Uint8Array([0x03]),
                 new Uint8Array(Buffer.from(prefix, 'utf-8')),
-                new Uint8Array(neonContractAddressBytes)
+                new Uint8Array(neonContractAddressBytes),
+                Buffer.from(Buffer.concat([Buffer.alloc(12), Buffer.from(config.utils.isValidHex(salt) ? salt.substring(2) : salt, 'hex')]), 'hex')
             ];
-
-            if (salt != undefined) {
-                seed.push(Buffer.from(Buffer.concat([Buffer.alloc(12), Buffer.from(config.utils.isValidHex(salt) ? salt.substring(2) : salt, 'hex')]), 'hex'));
-            }
         
             return web3.PublicKey.findProgramAddressSync(seed, neonEvmProgram);
         },


### PR DESCRIPTION
**Change log:**
1. Removed not needed check `if (ataAccount != bytes32(0)) {` inside `balanceOf`
2. Added two additional external getter methods `balanceOfPDA` & `balanceOfATA`
3. Updated comments of `claim`, `claimTo`, `burn`, `burnFrom`, `transferSolana` & `transferSolanaFrom` that their getter is `balanceOfPDA` _( these methods are not mean to be used by Solana users )_
4. Optimized `_getSolanaATA` to not always request `getAccount`
5. Applied "cosmetic" changes to `ERC20ForSplFactory`:
     * Upgraded to latest stable pragma version 0.8.28
     * Changed the importing to explicit importing
     * Changed string errors to custom ones
     * Moved `salt` keccak256 into the assembly block
     * Add getter method `getTokenMintByAddress` - currently until now it was impossible to get token address by the token mint. This method will enable this in order to make the integrations of factory concepts easier 
     * Added comments in general
     * Added tests for the factory it self