### PR TITLE
Fix typo in ISPLTokenProgram.sol and minor formatting update

### DIFF
--- a/contracts/precompiles/ISPLTokenProgram.sol
+++ b/contracts/precompiles/ISPLTokenProgram.sol
@@ -26,7 +26,7 @@ interface ISPLTokenProgram {
         bytes32 mintAuthority;
     }
 
-    /// @notice Getter returing the user's ATA in bytes32 format for this SPLToken
+    /// @notice Getter returning the user's ATA in bytes32 format for this SPLToken
     function findAccount(bytes32 salt) external pure returns(bytes32);
 
     /// @notice Check if account is a system account. System account is not owned by anyone until it's initialized.


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the @notice comment for the findAccount function in the ISPLTokenProgram.sol interface ("returing" → "returning"). Additionally, it updates the formatting of the closing bracket at the end of the interface. No functional changes to the contract logic were made.
